### PR TITLE
DDF-4274 Changed default config for URL Resource Reader to allow redirects

### DIFF
--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -102,7 +102,7 @@ public class URLResourceReader implements ResourceReader {
 
   private Set<String> rootResourceDirectories = new HashSet<>();
 
-  private boolean followRedirects = false;
+  private boolean followRedirects = true;
 
   /** Default URLResourceReader constructor. */
   public URLResourceReader(ClientFactoryFactory clientFactoryFactory) {

--- a/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
                 <AD
                 description="Check the box if you want the Resource Reader to automatically follow server issued redirects (HTTP Response Code 300 series)"
                 name="Follow Server Redirects" id="followRedirects" required="true"
-                type="Boolean" default="false"/>
+                type="Boolean" default="true"/>
          
                 <AD
                 description="List of root resource directories. A relative path is relative to ddf.home. Specifies the only directories the URLResourceReader has access to when attempting to download resources linked using file-based URLs."


### PR DESCRIPTION
#### What does this PR do?

Fixes an issue causing downloading from resource URI links on metacards to fail if redirects are encountered.

#### Who is reviewing it?

@peterhuffer @pvargas @oconnormi @kcover

#### Select relevant component teams: 

@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@coyotesqrl

#### How should this be tested?

- Navigate to `Catalog -> Configuration -> URL Resource Reader` and verify that the box for `Follow Server Redirects` is checked.
- Set up a fanout proxy and search for a metacard with a valid `resource-download-uri` attribute and click the link for it in Intrigue
- Verify that the file is successfully downloaded

#### What are the relevant tickets?
[DDF-4274](https://codice.atlassian.net/browse/DDF-4274)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
